### PR TITLE
package.json: use browser assert for assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "ruby",
     "furigana"
   ],
+  "browser": {
+    "assert": "browser-assert"
+  },
   "author": "LaySent <laysent@gmail.com>",
   "license": "MIT",
   "bugs": {
@@ -28,6 +31,7 @@
     "lib"
   ],
   "dependencies": {
+    "browser-assert": "^1.2.1",
     "micromark": "^2.11.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,6 +909,11 @@ braces@^3.0.1:
   dependencies:
     fill-range "^7.0.1"
 
+browser-assert@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/browser-assert/-/browser-assert-1.2.1.tgz#9aaa5a2a8c74685c2ae05bfe46efd606f068c200"
+  integrity sha1-mqpaKox0aFwq4Fv+Ru/WBvBowgA=
+
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"


### PR DESCRIPTION
In browsers, assert is not available by default. Some bundlers
like esbuild do not swap in node-api equivalents by default. This
change hints to bundlers to use browser-assert in those cases.

There shouldn't be a change in behavior otherwise.